### PR TITLE
Changed code sample references in text

### DIFF
--- a/src/02. Content/07. Regions.md
+++ b/src/02. Content/07. Regions.md
@@ -57,7 +57,7 @@ When defining a region with the `RegionAttribute` you can set the following prop
 public MarkdownField MainContent { get; set; }
 ~~~
 
-Optional title to be shown in the manager interface. If this property is left empty the **property name** is used. The example below shows a single field region in a Content Type.
+Optional title to be shown in the manager interface. If this property is left empty the **property name** is used. The example above shows a single field region in a Content Type.
 
 ##### ListTitle
 
@@ -77,7 +77,7 @@ public class MyRegion
 public IList<MyRegion> Teasers { get; set; }
 ~~~
 
-The optional **field name** of a composite region that should be used when rendering the collapsed list items in the manager interface. The example below shows a **composite region** that is made up of a `StringField` and a `TextField`.
+The optional **field name** of a composite region that should be used when rendering the collapsed list items in the manager interface. The example above shows a **composite region** that is made up of a `StringField` and a `TextField`.
 
 ##### ListExpand
 
@@ -86,7 +86,7 @@ The optional **field name** of a composite region that should be used when rende
 public IList<ImageField> Images { get; set; }
 ~~~
 
-If the list item should be expandable or if the fields should be shown directly in the list. The default behavior is `true` but it can be useful to set it to `false` if you have a single field region or a very simple list region. The example below will create a list of image fields and show them directly in the list.
+If the list item should be expandable or if the fields should be shown directly in the list. The default behavior is `true` but it can be useful to set it to `false` if you have a single field region or a very simple list region. The example above will create a list of image fields and show them directly in the list.
 
 ##### SortOrder
 


### PR DESCRIPTION
The text refers to the example below when the sample code is above. Changed 'below' to 'above' where appropriate. One could move the sample code also I guess...