### PR TITLE
Correct PageType to SiteType

### DIFF
--- a/src/02. Content/02. Sites.md
+++ b/src/02. Content/02. Sites.md
@@ -20,7 +20,7 @@ using Piranha.Extend;
 using Piranha.Extend.Fields;
 using Piranha.Models;
 
-[PageType(Title = "Simple Site")]
+[SiteType(Title = "Simple Site")]
 public class SimpleSite : SiteContent<SimpleSite>
 {
     [Region]


### PR DESCRIPTION
Unsure if this was intentional, as `PageType` does in fact work, but this content suggests the documentation should be referring to `SiteType` - this caused me a couple hours of hassle trying to figure out why it wasn't being registered as a site type.