### PR TITLE
Fixed a typo on the Application/Hooks page - corrected Page to Pages

### DIFF
--- a/src/03. Application/07. Hooks.md
+++ b/src/03. Application/07. Hooks.md
@@ -66,13 +66,13 @@ App.Hooks.MediaFolder.RegisterOnAfterDelete((folder) => { ... });
 The following hooks are available when accessing pages through the `PageService`. Please note that all models are passed in as `Piranha.Models.PageBase` and must be casted to the applicable type.
 
 ~~~ csharp
-App.Hooks.Page.RegisterOnLoad((page) => { ... });
+App.Hooks.Pages.RegisterOnLoad((page) => { ... });
 
-App.Hooks.Page.RegisterOnBeforeSave((page) => { ... });
-App.Hooks.Page.RegisterOnAfterSave((page) => { ... });
+App.Hooks.Pages.RegisterOnBeforeSave((page) => { ... });
+App.Hooks.Pages.RegisterOnAfterSave((page) => { ... });
 
-App.Hooks.Page.RegisterOnBeforeDelete((page) => { ... });
-App.Hooks.Page.RegisterOnAfterDelete((page) => { ... });
+App.Hooks.Pages.RegisterOnBeforeDelete((page) => { ... });
+App.Hooks.Pages.RegisterOnAfterDelete((page) => { ... });
 ~~~
 
 ## Params


### PR DESCRIPTION
Fixed a minor typo on the Application/Hooks page. The examples for the Pages were using "App.Hooks.Page" when it needs to be "App.Hooks.Pages".

