### PR TITLE
Added a FAQs section and added example of how to create a footer

### DIFF
--- a/src/08. FAQs/01. How to create a footer.md
+++ b/src/08. FAQs/01. How to create a footer.md
@@ -1,0 +1,96 @@
+# Create a footer
+
+A common feature of websites is to have a footer which appears on the bottom of every webpage across a website.
+
+In this example, we are going to create a simple footer with two elements:
+
+- A small image which could be something like a company logo for example
+- Some text such as copyright information or a contact address
+
+You can, of course, add extra fields if you like but this example will hopefully show you how to get started.
+
+## Step 1 : Create a site type 
+
+We are going to create a new **site type** which will contain our footer fields. 
+
+Create a folder called Models and insite that, create another folder called SiteTypes. Inside SiteTypes, add a class called DemoSite and use the code below:
+
+~~~ csharp
+using Piranha.AttributeBuilder;
+using Piranha.Extend;
+using Piranha.Models;
+using Piranha.Extend.Fields;
+
+[SiteType(Title = "Demo site")]
+public class DemoSite : SiteContent<DemoSite>
+{
+    [Region(Title = "Footer", Display =RegionDisplayMode.Setting)]
+    public Footer FooterContents { get; set; }
+}
+~~~
+
+## Step 2 : Creating fields for the footer ##
+
+Now we have a **site type** created with a property called **Footer** we can now add fields onto it which can be edited in Piranha. 
+
+To keep things simple, add this class in DemoSite.cs:
+
+~~~ csharp
+    public class Footer
+    {
+        [Field(Title = "Footer logo")]
+        public ImageField Logo { get; set; }
+
+        [Field(Title ="Footer text")]
+        public HtmlField Text { get; set; }
+    }
+~~~
+
+## Step 4 : Add the footer to the _Layout.cshtml page
+
+Now we have created our site type and footer class, we now need to display the footer on every page. To do this, add this HTML snippet to your _Layout.csthml page:
+
+~~~ csharp
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            @{
+                var currentSite = await WebApp.Site.GetContentAsync<DemoSite>();
+            }
+            <div class="row">
+                <div class="col-4">
+                    <img src="@Url.Content(currentSite.FooterLogo)" style="width:100px; height: 100px;" />
+                </div>
+                <div class="col-4">
+                    @Html.Raw(currentSite.FooterContents.Logo)
+                </div>
+                <div class="col-4">
+                    @Html.Raw(currentSite.FooterContents.Text)
+                </div>
+            </div>
+        </div>
+    </footer>
+~~~
+
+## Step 4 : Update the default site type to be a DemoSite tyoe
+
+We have now created our **site type** along with it's footer fields. Now, we want to login to the Piranha manager and add some content. To do this, we need to change the **Content Type** of the **Default Site**. 
+
+Follow these steps:
+
+1. Login to the Piranha manager
+2. Click on **Default Site** and a popup will appear
+3. In the **Edit site** popup, there is a drop down list underneath "Content Type". Change this to "Demo site"
+4. Click **Save**
+5. Reload the manager page to update the manager view
+
+If you click on **Detault Site** now, you will see a new tab called "Footer content" and you can now enter content for the footer.
+
+## Step 5 : View in the browser!
+
+You you now view your website, you should see the small logo and text in your footer.
+
+
+
+
+
+


### PR DESCRIPTION
Hi @tidyui 

I've added a new section to the documentation called "FAQs". Inside that I've added an an example of how to create a site-wide footer. 

I couldn't get Statica working so couldn't test it there, but it looks fine on Markdown preview.