### PR TITLE
Corrected references to 'empty' project in Options

### DIFF
--- a/src/01. Basics/03. Project Templates.md
+++ b/src/01. Basics/03. Project Templates.md
@@ -70,7 +70,7 @@ Creates an application for `ASP.NET MVC` with some default `Content Types` and `
 
 ### Options
 
-The following options are available when generating an empty project.
+The following options are available when generating a MVC project.
 
 ~~~ bash
 -d|--database   Specifies the database provider that should be used
@@ -150,7 +150,7 @@ Creates an application for `Razor Pages` with some default `Content Types` and `
 
 ### Options
 
-The following options are available when generating an empty project.
+The following options are available when generating a Razor project.
 
 ~~~ bash
 -d|--database   Specifies the database provider that should be used


### PR DESCRIPTION
Options in this section are referencing the type of project dotnet new from a few lines above. I suspect the 'empty project' was a copy/paste.