### PR TITLE
Updated broken links in custom blocks and fields

### DIFF
--- a/src/02. Content/06. Blocks/01. Custom Blocks.md
+++ b/src/02. Content/06. Blocks/01. Custom Blocks.md
@@ -1,6 +1,6 @@
 # Custom Blocks
 
-> This article covers how to implement custom blocks for Piranha. If you want to read more about the standard blocks included, please refer to [Blocks](../).
+> This article covers how to implement custom blocks for Piranha. If you want to read more about the standard blocks included, please refer to [Blocks](./).
 
 Blocks are the content pieces that the Administrators can use when designing the main content body. They main difference between `Fields` and `Blocks` is that blocks are intended to be more visual in their presentation than fields to give editors a clear understanding of the content they are creating.
 
@@ -155,7 +155,7 @@ Piranha.App.Blocks.Register<MyCustomBlock>();
 
 ## Create The Manager Component
 
-The manager interface is based on `Vue.js` and assumes that all blocks are registered as **global components**. As these components are written in `Javascript` you need to register your custom resources in the manager. For more information about this, please refer to [Resources](../manager-extensions/resources) in the section **Manager Extensions**.
+The manager interface is based on `Vue.js` and assumes that all blocks are registered as **global components**. As these components are written in `Javascript` you need to register your custom resources in the manager. For more information about this, please refer to [Resources](../../manager-extensions/resources) in the section **Manager Extensions**.
 
 > ##### A note on block templates
 > The root element of the block template **needs** to have the class `block-body` for the manager interface

--- a/src/02. Content/06. Blocks/02. Custom Block Groups.md
+++ b/src/02. Content/06. Blocks/02. Custom Block Groups.md
@@ -1,6 +1,6 @@
 # Custom Block Groups
 
-> This article covers how to implement custom block groups for Piranha. If you want to read more about the standard blocks included, please refer to [Blocks](../).
+> This article covers how to implement custom block groups for Piranha. If you want to read more about the standard blocks included, please refer to [Blocks](./).
 
 A Block Group is a special kind of block that can have child items. Just like regular blocks, block groups can have Field Properties defined. These fields are **global** for the group and are displayed above the actual items.
 

--- a/src/02. Content/08. Fields/01. Custom Fields.md
+++ b/src/02. Content/08. Fields/01. Custom Fields.md
@@ -1,6 +1,6 @@
 # Custom Fields
 
-> This article covers how to implement custom fields for Piranha. If you want to read more about the standard field included, please refer to [Fields](../).
+> This article covers how to implement custom fields for Piranha. If you want to read more about the standard field included, please refer to [Fields](./).
 
 Fields are the lowest level of content in Piranha CMS and are used to build up **Regions** and **Blocks**. In many cases the fields included in Piranha are sufficient, but you might also want to create custom fields for you application. One use case is for example if you would like to reference a custom entity in your application from a Page or Post, much like the included `PageField` does.
 


### PR DESCRIPTION
Fixed links:
- 02\. Content/06. Blocks/01. Custom Blocks.md
  - Link to "Blocks" previously redirected to "Content"
  - Link to "Resources" redirected to a 404 error
- 02\. Content/06. Blocks/02. Custom Block Groups.md
  - Link to "Blocks" previously redirected to "Content"
- 02\. Content/08. Fields/01. Custom Fields.md
  - Link to "Fields" previously redirected to "Content"