### PR TITLE
Spelling mistake

### DIFF
--- a/src/01. Basics/08. Configuration.md
+++ b/src/01. Basics/08. Configuration.md
@@ -81,7 +81,7 @@ The number of comments that should be returned when loading a comment list. A va
 config.HtmlExcerpt = false;
 ~~~
 
-If the Page & Post excerpt should be in HTML or in plain text. The defailt value is **false**.
+If the Page & Post excerpt should be in HTML or in plain text. The default value is **false**.
 
 #### MediaCDN
 


### PR DESCRIPTION
Changed from "defailt" to "default"